### PR TITLE
Fix installation, environment, and protein FASTA handling issues

### DIFF
--- a/00_scripts/05_repeatmodeler.sh
+++ b/00_scripts/05_repeatmodeler.sh
@@ -180,6 +180,8 @@ cat Round*bed >> ../03_genome/raw."$database".TE.bed
 #make overly simplistic filtered bed: 
 grep -v "Simple\|Low\|Unsp" ../03_genome/raw."$database".TE.bed > ../03_genome/filtered."$database".TE.bed
 
+conda activate superannot
+
 if [[ $rm_unknown = "YES" ]]
 then
    bedtools maskfasta -soft \
@@ -207,5 +209,4 @@ fi
 #
 
 #cd ../03_genome || exit
-
 

--- a/00_scripts/08_braker_reshaping.sh
+++ b/00_scripts/08_braker_reshaping.sh
@@ -215,6 +215,8 @@ echo output cds is "$output"
 gffread -x 08_best_run/01_haplo_cds/"$output" \
         -g "${genome}" "$gtffull"
 
+conda activate superannot
+
 #then convert also the file to its cds:
 echo "translate CDS into amino acid "
 transeq -sequence 08_best_run/01_haplo_cds/"$output" \
@@ -375,6 +377,8 @@ echo -e "-----------------------------------------------------------------\n"
 gffread -x "$haplo".spliced_cds.fa -g ../03_genome/genome.wholemask.fa "$gtf4" 
 echo "translate CDS into amino acid "
 gffread -y "$haplo"_prot.final.clean.fa -g ../03_genome/genome.wholemask.fa "$gtf4"
+
+conda activate superannot
 
 #transeq -sequence "$haplo".spliced_cds.fa \
 #    -outseq "$haplo"_prot.final.fa

--- a/00_scripts/08_braker_reshaping.sh
+++ b/00_scripts/08_braker_reshaping.sh
@@ -377,6 +377,7 @@ echo -e "-----------------------------------------------------------------\n"
 gffread -x "$haplo".spliced_cds.fa -g ../03_genome/genome.wholemask.fa "$gtf4" 
 echo "translate CDS into amino acid "
 gffread -y "$haplo"_prot.final.clean.fa -g ../03_genome/genome.wholemask.fa "$gtf4"
+sed -i '/^>/!s/\./*/g' "$haplo"_prot.final.clean.fa
 
 conda activate superannot
 
@@ -384,6 +385,7 @@ conda activate superannot
 #    -outseq "$haplo"_prot.final.fa
 transeq -clean -sequence "$haplo".spliced_cds.fa \
     -outseq "$haplo"_prot.final.fa #for interproscan and other pipelines
+sed -i '/^>/!s/\./*/g' "$haplo"_prot.final.fa
 
 echo -e "there is $( grep -c ">" "$haplo"_prot.final.fa |\
     awk '{print $1}' ) total protein corresponding to a single longest transcript in the final files"

--- a/00_scripts/Rscripts/03.plot_paml.R
+++ b/00_scripts/Rscripts/03.plot_paml.R
@@ -228,7 +228,7 @@ if (argv[1]=="-h" || length(argv)==0){
       xlab("order along reference") +
       ylab( expression(italic(d[S]))) +
       th_plot + theme(legend.position = "none") +
-      scale_color_manual(values=wes_palette(n=ncolors, name="GrandBudapest1")) +
+      scale_color_manual(values=colorRampPalette(wes_palette(name="GrandBudapest1"))(ncolors)) +
       ggtitle("B") 
     
     #create dir if not present:

--- a/00_scripts/slurm_code/06_reshape_braker_output.sh
+++ b/00_scripts/slurm_code/06_reshape_braker_output.sh
@@ -374,9 +374,11 @@ echo -e "-----------------------------------------------------------------\n"
 gffread -w "$haplo".spliced_cds.fa -g ../03_genome/genome.wholemask.fa "$gtf4" 
 echo "translate CDS into amino acid "
 gffread -y "$haplo"_prot.final.clean.fa -g ../03_genome/genome.wholemask.fa "$gtf4"
+sed -i '/^>/!s/\./*/g' "$haplo"_prot.final.clean.fa
 
 transeq -clean -sequence  "$haplo".spliced_cds.fa \
     -outseq "$haplo"_prot.final.fa
+sed -i '/^>/!s/\./*/g' "$haplo"_prot.final.fa
 #transeq -clean -sequence "$haplo".spliced_cds.fa \
 #    -outseq "$haplo"_prot.final.clean.fa #for interproscan and other pipelines
 

--- a/00_scripts/slurm_code/07_dataprep_opt3_opt4_opt5.sh
+++ b/00_scripts/slurm_code/07_dataprep_opt3_opt4_opt5.sh
@@ -142,7 +142,7 @@ source config/cpu_mem
             exit
         else
             gffread -g "$genome1" -y haplo1/08_best_run/"$haplotype1"_prot.final.clean.fa "$gtf1"
-            sed -i '/^>/!s/./*/g' haplo1/08_best_run/"$haplotype1"_prot.final.clean.fa 
+            sed -i '/^>/!s/\./*/g' haplo1/08_best_run/"$haplotype1"_prot.final.clean.fa 
             #transeq -sequence haplo1/08_best_run/"$haplotype1".spliced_cds.fa \
             #        -outseq haplo1/08_best_run/"$haplotype1"_prot.final.clean.fa
 
@@ -218,4 +218,3 @@ source config/cpu_mem
              grep -v "$haplotype1" "$TEgenome1" > haplo1/03_genome/filtered."$haplotype1".TE.bed 
          fi
     fi
-

--- a/INSTALL/dependencies.sh
+++ b/INSTALL/dependencies.sh
@@ -11,12 +11,39 @@ then
     exit 1
 fi
 
+#option 1: local install
+# SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# EASYSTRATA_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+# PROFILE_PATH="$EASYSTRATA_ROOT/path.sh"
+#option 2: global install
+PROFILE_PATH="$HOME/.bashrc"
+
+touch "$PROFILE_PATH"
+source "$PROFILE_PATH"
+eval "$(mamba shell hook --shell bash)"
+mamba activate superannot
+
+Rscript -e 'if (!requireNamespace("devtools", quietly=TRUE)) install.packages("devtools")' || \
+    { echo -e "ERROR!\ndevtools installation failed\ncheck your R setup\n" ; exit 1 ; }
+
+Rscript -e 'if (!requireNamespace("remotes", quietly=TRUE)) install.packages("remotes")' || \
+    { echo -e "ERROR!\nremotes installation failed\ncheck your R setup\n" ; exit 1 ; }
+
+Rscript -e 'if (!requireNamespace("BiocManager", quietly=TRUE)) install.packages("BiocManager")' || \
+    { echo -e "ERROR!\nBiocManager installation failed\ncheck your R setup\n" ; exit 1 ; }
+
+Rscript -e 'if (!requireNamespace("Biostrings", quietly=TRUE)) BiocManager::install("Biostrings", ask=FALSE, update=FALSE)' || \
+    { echo -e "ERROR!\nBiostrings installation failed\ncheck your R/Bioconductor setup\n" ; exit 1 ; }
+
+Rscript -e 'remotes::install_version("ggplot2", version="3.5.1", upgrade="never")' || \
+    { echo -e "ERROR!\nggplot2 installation failed\ncheck your R setup\n" ; exit 1 ; }
+
 #install GeneSpace first:
 Rscript -e  'devtools::install_github("jtlovell/GENESPACE")' || \
     { echo -e "ERROR!\nGeneSpace installation failed\ncheck conda dependencies\n" ; exit 1 ; }
 
 # test each command one by one and install them if necessary:
-mkdir softs
+mkdir -p softs
 cd softs 
 
 
@@ -33,8 +60,8 @@ then
     if [ $? -eq 0 ]; then
         echo $command installation worked successfully
 	MCScanpath=$(pwd)
-        echo -e "\n#Path to $command\nexport PATH=\$PATH:$MCScanpath" >> ~/.bashrc 
-        source ~/.bashrc  
+        echo -e "\n#Path to $command\nexport PATH=\$PATH:$MCScanpath" >> "$PROFILE_PATH"
+        source "$PROFILE_PATH"
         cd ../
 
     else
@@ -56,8 +83,8 @@ then
     cd BRAKER/scripts 
     chmod a+x *.pl *.py
     path=$(pwd)
-    echo -e "\n#Path to $command\nexport PATH=\$PATH:$path" >> ~/.bashrc 
-    source ~/.bashrc  
+    echo -e "\n#Path to $command\nexport PATH=\$PATH:$path" >> "$PROFILE_PATH"
+    source "$PROFILE_PATH"
     cd ../../
 else 
     echo -e "\ncommand $command already installed\nskipping installation\n\n"
@@ -73,11 +100,11 @@ then
     wget -q https://github.com/gatech-genemark/ProtHint/releases/download/v2.6.0/ProtHint-2.6.0.tar.gz 
     tar zxvf ProtHint-2.6.0.tar.gz
     cd ProtHint-2.6.0/bin 
-    #then add to ~/.bashrc
+    #then add to $PROFILE_PATH
     protpath=$(pwd)
-    echo -e "\n#Path to $command\nexport PROTHINT_PATH=:$protpath" >> ~/.bashrc 
-    echo -e "\nexport PATH=\$PATH:$protpath" >> ~/.bashrc
-    source ~/.bashrc  
+    echo -e "\n#Path to $command\nexport PROTHINT_PATH=:$protpath" >> "$PROFILE_PATH"
+    echo -e "\nexport PATH=\$PATH:$protpath" >> "$PROFILE_PATH"
+    source "$PROFILE_PATH"
     cd ../../
 else 
     echo -e "\ncommand $command already installed\nskipping installation\n\n"
@@ -94,10 +121,10 @@ then
     mkdir diamond ; cd diamond
     wget -q https://github.com/bbuchfink/diamond/releases/download/v2.1.1/diamond-linux64.tar.gz
     tar zxvf diamond-linux64.tar.gz
-    #then add to ~/.bashrc
+    #then add to $PROFILE_PATH
     path=$(pwd)
-    echo -e "\n#Path to $command\nexport PATH=\$PATH:$path" >> ~/.bashrc 
-    source ~/.bashrc  
+    echo -e "\n#Path to $command\nexport PATH=\$PATH:$path" >> "$PROFILE_PATH"
+    source "$PROFILE_PATH"
     cd ../ 
 else 
     echo -e "\ncommand $command already installed\nskipping installation\n\n"
@@ -116,9 +143,9 @@ then
     if [ $? -eq 0 ]; then
         echo $command installation worked successfully
         cdbpath=$(pwd)
-        echo -e "\n#Path to $command\nexport CDBTOOLS_PATH=$cdbpath" >> ~/.bashrc 
-        echo -e "\nexport PATH=\$PATH:$cdbpath" >> ~/.bashrc
-        source ~/.bashrc  
+        echo -e "\n#Path to $command\nexport CDBTOOLS_PATH=$cdbpath" >> "$PROFILE_PATH"
+        echo -e "\nexport PATH=\$PATH:$cdbpath" >> "$PROFILE_PATH"
+        source "$PROFILE_PATH"
 	cd ../
     else
         echo -e "\n#ERROR : Installation failed please check everything"  
@@ -138,9 +165,9 @@ if ! command -v $command &> /dev/null
     cd GeneMark-ETP/
     cd bin/gmes
     gmarkpath=$(pwd)
-    echo -e "export GENEMARK_PATH=$gmarkpath/ " >> ~/.bashrc
-    echo -e "\nexport PATH=\$PATH:$gmarkpath" >> ~/.bashrc
-    source ~/.bashrc  
+    echo -e "export GENEMARK_PATH=$gmarkpath/ " >> "$PROFILE_PATH"
+    echo -e "\nexport PATH=\$PATH:$gmarkpath" >> "$PROFILE_PATH"
+    source "$PROFILE_PATH"
     cd ../../../ 
 else 
     echo -e "\ncommand $command already installed\nskipping installation\n\n"
@@ -156,10 +183,10 @@ if ! command -v $command &> /dev/null
     git clone https://github.com/Gaius-Augustus/TSEBRA 
     cd TSEBRA/bin
     tsebrapath=$(pwd)
-    echo -e "\n#Path to $command\nexport TSEBRA_PATH=$tsebrapath" >> ~/.bashrc 
-    echo -e "\n#Path to $command\nexport PATH=\$PATH:$tsebrapath" >> ~/.bashrc 
+    echo -e "\n#Path to $command\nexport TSEBRA_PATH=$tsebrapath" >> "$PROFILE_PATH"
+    echo -e "\n#Path to $command\nexport PATH=\$PATH:$tsebrapath" >> "$PROFILE_PATH"
 
-    source ~/.bashrc  
+    source "$PROFILE_PATH"
     cd ../../
 else 
     echo -e "\ncommand $command already installed\nskipping installation\n\n"
@@ -183,8 +210,8 @@ if ! command -v $command &> /dev/null
         echo $command installation worked successfully
 	cd bin/
         path=$(pwd)
-        echo -e "\n#Path to $command\nexport PATH=\$PATH:$path" >> ~/.bashrc 
-        source ~/.bashrc  
+        echo -e "\n#Path to $command\nexport PATH=\$PATH:$path" >> "$PROFILE_PATH"
+        source "$PROFILE_PATH"
         cd ../../
     else
        echo installation failed\nmake sur to have git, make and gclib
@@ -208,8 +235,8 @@ if ! command -v $command &> /dev/null
     if [ $? -eq 0 ]; then
         echo $command installation worked successfully
         path=$(pwd)
-        echo -e "\n#Path to $command\nexport PATH=\$PATH:$path" >> ~/.bashrc 
-        source ~/.bashrc  
+        echo -e "\n#Path to $command\nexport PATH=\$PATH:$path" >> "$PROFILE_PATH"
+        source "$PROFILE_PATH"
         cd ../
 
     else
@@ -231,14 +258,14 @@ then
     cd OrthoFinder
     #if command was successfull then add to path:
     path=$(pwd)
-    echo -e "\n#Path to $command\nexport PATH=\$PATH:$path" >> ~/.bashrc 
-    source ~/.bashrc  
+    echo -e "\n#Path to $command\nexport PATH=\$PATH:$path" >> "$PROFILE_PATH"
+    source "$PROFILE_PATH"
     
     #also add diamond, fastme and mcl which are present within orthofinder:
     cd bin/
     path=$(pwd)
-    echo -e "\n#Path to diamond\n export PATH=\$PATH:$path" >> ~/.bashrc 
-    source ~/.bashrc  
+    echo -e "\n#Path to diamond\n export PATH=\$PATH:$path" >> "$PROFILE_PATH"
+    source "$PROFILE_PATH"
     cd ../../
     #exit 1
 else 
@@ -261,8 +288,8 @@ then
    ln -s muscle3.8.31_i86linux64 muscle
    chmod +x muscle
    path=$(pwd)
-   echo -e "\n#Path to $command\n export PATH=\$PATH:$path" >> ~/.bashrc 
-   source ~/.bashrc  
+   echo -e "\n#Path to $command\n export PATH=\$PATH:$path" >> "$PROFILE_PATH"
+   source "$PROFILE_PATH"
    cd ../
 else 
     echo -e "\ncommand $command already installed\nskipping installation\n\n"
@@ -278,8 +305,8 @@ then
    wget -q https://www.agap-ge2pop.org/wp-content/uploads/macse/releases/macse_v2.07.jar
    chmod +x macse*jar
    path=$(pwd)
-   echo -e "\n#Path to $command\n export PATH=\$PATH:$path" >> ~/.bashrc 
-   source ~/.bashrc  
+   echo -e "\n#Path to $command\n export PATH=\$PATH:$path" >> "$PROFILE_PATH"
+   source "$PROFILE_PATH"
    cd ../
 else 
     echo -e "\ncommand $command already installed\nskipping installation\n\n"
@@ -312,8 +339,8 @@ then
    mv baseml basemlg chi2 codeml evolver infinitesites mcmctree pamp yn00 ../bin
    cd ../bin
    path=$(pwd)
-   echo -e "\n#Path to $command\n export PATH=\$PATH:$path" >> ~/.bashrc 
-   source ~/.bashrc  
+   echo -e "\n#Path to $command\n export PATH=\$PATH:$path" >> "$PROFILE_PATH"
+   source "$PROFILE_PATH"
    cd ../../
 else 
     echo -e "\ncommand $command already installed\nskipping installation\n\n"
@@ -332,8 +359,8 @@ then
     cd translatorx 
     chmod +x translatorx_vLocal.pl
     path=$(pwd)
-    echo -e "\n#Path to translatorx\n export PATH=\$PATH:$path" >> ~/.bashrc 
-    source ~/.bashrc  
+    echo -e "\n#Path to translatorx\n export PATH=\$PATH:$path" >> "$PROFILE_PATH"
+    source "$PROFILE_PATH"
     cd ../
 else 
     echo -e "\ncommand $command already installed\nskipping installation\n\n"
@@ -367,8 +394,8 @@ then
 	cd ../src
 	#$(find . -name "bamtools" )
         path=$(pwd)
-        echo -e "\n#Path to $command\nexport PATH=\$PATH:$path" >> ~/.bashrc 
-        source ~/.bashrc  
+        echo -e "\n#Path to $command\nexport PATH=\$PATH:$path" >> "$PROFILE_PATH"
+        source "$PROFILE_PATH"
         cd ../../../
     else
        echo installation failed\nmake sur to have git, make and cmake
@@ -398,6 +425,7 @@ then
         echo $command installation worked successfully
 
         htpath="$(echo $(pwd)"/include/htslib/")"
+        htlpath="$(echo $(pwd)"/lib/")"
         cd ../
     else
         echo installation of $command failed! check the logs
@@ -407,6 +435,7 @@ else
     #note: should be installed from braker_env (through minimap2)
     htcmd=$(command -v "$command")
     htpath=$(echo $htcmd |sed 's/bin\/htsfile/include\/htslib/')
+    htlpath=$(echo $htcmd |sed 's/bin\/htsfile/lib/')
 fi
 
 #in case this did not work test this: 
@@ -447,19 +476,19 @@ then
     sed -i "s#usr/include/htslib#$htpath#g" common.mk
 
     n=$(grep -n "LIBRARY_PATH_HTSLIB" common.mk |awk -F":" '{print $1}' )
-    sed -i  "${n}s#usr/lib/x86_64-linux-gnu#$htpath/lib#g" common.mk
+    sed -i  "${n}s#usr/lib/x86_64-linux-gnu#$htlpath#g" common.mk
     #attempt to make augustus:
     make augustus
     #if all was succesffull: ""
     if [ $? -eq 0 ]; then
         echo $command installation worked successfully
         augustuspath=$(pwd)
-	    echo -e "#path to AUGUSTUS:" >> ~/.bashrc 
-        echo -e "export AUGUSTUS_CONFIG_PATH=$augustuspath/config " >> ~/.bashrc
-        echo -e "export AUGUSTUS_BIN_PATH=$augustuspath/bin/ " >> ~/.bashrc
-	    echo -e "export PATH=\$PATH:$augustuspath/bin" >> ~/.bashrc
-        echo -e "export AUGUSTUS_SCRIPTS_PATH=/$augustuspath/augustus_scripts " >> ~/.bashrc
-	source ~/.bashrc
+	    echo -e "#path to AUGUSTUS:" >> "$PROFILE_PATH"
+        echo -e "export AUGUSTUS_CONFIG_PATH=$augustuspath/config " >> "$PROFILE_PATH"
+        echo -e "export AUGUSTUS_BIN_PATH=$augustuspath/bin/ " >> "$PROFILE_PATH"
+	    echo -e "export PATH=\$PATH:$augustuspath/bin" >> "$PROFILE_PATH"
+        echo -e "export AUGUSTUS_SCRIPTS_PATH=/$augustuspath/augustus_scripts " >> "$PROFILE_PATH"
+	source "$PROFILE_PATH"
 	cd ./auxprogs/joingenes
 	make -j8
         cd ../bam2hints

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Again, all input data, including full path to input files, should be provided in
 all options
 * **Input genome(s)** - compulsory: This may be one genome assembly containing both sex/mating type chromosomes, or **ideally** two separate haplotype assemblies containing each one of the sex/mating-type chromosomes.
 * **list of scaffolds** - compulsory: names of the contigs/scaffolds/chromosomes composing the sex/mating-type chromosomes. see example [here](https://github.com/QuentinRougemont/EASYstrata/blob/main/example_data/scaffold.txt)
+  > :warning: **All entries must belong to haplotype 1 only.** Do not include chromosomes from haplotype 2. The plotting scripts assign all entries to haplotype 1 internally, so mixing both haplotypes will cause an error in `plot_riparian`.
 * **ancestral genome** - optional but highly recommended: The genome assembly of a species used as a proxy for the ancestral state. This will allow to plot d<sub>S</sub> along 'ancestral' gene order, and to infer more accurately single copy orthologs.
 * **ancestral gene prediction** - compulsory with ancestral genome: gene prediction associated with the ancestral genome. format: gtf/gff(.gz) 
 

--- a/master.sh
+++ b/master.sh
@@ -7,6 +7,137 @@ source config/colors
 source ./config/config 
 
 ############################################################
+# Input validation helpers                                 #
+############################################################
+
+validation_error()
+{
+    echo -e "\n${RED}INPUT VALIDATION ERROR:${NC} $1\n" >&2
+    exit 1
+}
+
+validate_simple_id()
+{
+    local label="$1"
+    local value="$2"
+
+    if [ -z "$value" ] ; then
+        return 0
+    fi
+
+    if [[ ! "$value" =~ ^[A-Za-z0-9_]+$ ]] ; then
+        validation_error "$label '$value' contains unsupported characters.
+Allowed characters are letters, numbers and underscore only."
+    fi
+}
+
+validate_fasta_headers()
+{
+    local fasta="$1"
+    local expected_prefix="$2"
+    local label="$3"
+
+    if [ ! -s "$fasta" ] ; then
+        validation_error "$label FASTA '$fasta' is missing or empty."
+    fi
+
+    awk -v prefix="$expected_prefix" -v file="$fasta" '
+        BEGIN {
+            count = 0
+            bad = 0
+        }
+        /^>/ {
+            id = substr($1, 2)
+            full = substr($0, 2)
+
+            if (full != id) {
+                printf("%s: header contains whitespace or extra metadata: %s\n", file, $0) > "/dev/stderr"
+                bad = 1
+            }
+            if (id !~ /^[A-Za-z0-9_]+$/) {
+                printf("%s: header contains unsupported characters: %s\n", file, id) > "/dev/stderr"
+                bad = 1
+            }
+            if (id ~ /_1/) {
+                printf("%s: header contains forbidden substring _1: %s\n", file, id) > "/dev/stderr"
+                bad = 1
+            }
+            if (prefix != "" && id !~ ("^" prefix "_[A-Za-z0-9]+$")) {
+                printf("%s: header must follow [%s]_[chromosome] with no extra underscores: %s\n", file, prefix, id) > "/dev/stderr"
+                bad = 1
+            }
+            if (prefix == "" && split(id, parts, "_") != 2) {
+                printf("%s: header must follow [individual]_[chromosome]: %s\n", file, id) > "/dev/stderr"
+                bad = 1
+            }
+            count++
+        }
+        END {
+            if (count == 0) {
+                printf("%s: no FASTA headers were found.\n", file) > "/dev/stderr"
+                bad = 1
+            }
+            exit bad
+        }
+    ' "$fasta" || validation_error "invalid FASTA headers detected in $label ('$fasta').
+See README.md > Input data > WARNINGS for the required naming rules."
+}
+
+validate_gtf_gene_ids()
+{
+    local gtf="$1"
+    local expected_prefix="$2"
+    local label="$3"
+
+    if [ ! -s "$gtf" ] ; then
+        validation_error "$label annotation '$gtf' is missing or empty."
+    fi
+
+    awk -v prefix="$expected_prefix" -v file="$gtf" '
+        BEGIN {
+            count = 0
+            bad = 0
+        }
+        $0 !~ /^#/ && ($3 == "gene" || $3 == "transcript" || $3 == "mRNA") {
+            id = ""
+            if (match($0, /gene_id "[^"]+"/)) {
+                id = substr($0, RSTART + 9, RLENGTH - 10)
+            }
+            else {
+                printf("%s: missing gene_id at line %d\n", file, NR) > "/dev/stderr"
+                bad = 1
+                next
+            }
+            if (id !~ /^[A-Za-z0-9_]+$/) {
+                printf("%s: gene_id contains unsupported characters at line %d: %s\n", file, NR, id) > "/dev/stderr"
+                bad = 1
+            }
+            if (id ~ /_1/) {
+                printf("%s: gene_id contains forbidden substring _1 at line %d: %s\n", file, NR, id) > "/dev/stderr"
+                bad = 1
+            }
+            if (prefix != "" && id !~ ("^" prefix "_[A-Za-z0-9]+_[A-Za-z0-9]+$")) {
+                printf("%s: gene_id must follow [%s]_[chromosome]_[gene] with no extra underscores at line %d: %s\n", file, prefix, NR, id) > "/dev/stderr"
+                bad = 1
+            }
+            if (prefix == "" && split(id, parts, "_") != 3) {
+                printf("%s: gene_id must follow [individual]_[chromosome]_[gene] at line %d: %s\n", file, NR, id) > "/dev/stderr"
+                bad = 1
+            }
+            count++
+        }
+        END {
+            if (count == 0) {
+                printf("%s: no gene/transcript records with gene_id were found.\n", file) > "/dev/stderr"
+                bad = 1
+            }
+            exit bad
+        }
+    ' "$gtf" || validation_error "invalid gene_id format detected in $label ('$gtf').
+See README.md > Input data > WARNINGS for the required naming rules."
+}
+
+############################################################
 # Help                                                     #
 ############################################################
 Help()
@@ -87,13 +218,19 @@ then
     Help
     exit 2
 else 
+    if [ -n "${haplotype1}" ] ; then
+        validate_simple_id "haplotype1" "${haplotype1}"
+    fi
+    if [ -n "${haplotype2}" ] ; then
+        validate_simple_id "haplotype2" "${haplotype2}"
+    fi
+
     if [ -n "${genome1}" ] ; 
     then
         b1=$(basename "${genome1%.fa*}" )
-        if [[ "$b1" =~ [^a-zA-Z0-9.] ]] ; 
+        if [[ "$b1" =~ [^a-zA-Z0-9._-] ]] ; 
         then 
-            echo "error only alphanumeric character allowed in genomeIDs" 
-            echo "see readme.md on github"
+            validation_error "genome1 file basename '$b1' contains unsupported characters."
         else 
             echo "genome 1 is $genome1" 
         fi
@@ -101,10 +238,9 @@ else
     if [ -n "${genome2}" ] ;
     then
         b1=$(basename "${genome2%.fa*}" )
-        if [[ "$b1" =~ [^a-zA-Z0-9.] ]] ; 
+        if [[ "$b1" =~ [^a-zA-Z0-9._-] ]] ; 
         then 
-            echo "error only alphanumeric character allowed in genomeIDs" 
-            echo "see readme.md on github"
+            validation_error "genome2 file basename '$b1' contains unsupported characters."
         else 
             echo "genome 2 is $genome2" 
         fi
@@ -184,6 +320,8 @@ if [[ -z "${haplotype1}" ]] ; then
     haplotype1="$(basename "${genome1%.fa**}")"
 fi
 
+validate_simple_id "haplotype1" "${haplotype1}"
+
 # ----- check compression of fasta  ------ ##
 
 #eval "$(conda shell.bash hook)"
@@ -207,6 +345,12 @@ else
    cd ../../
 fi
 
+if [ -n "${genome2}" ] ; then
+    validate_fasta_headers "haplo1/03_genome/${haplotype1}.fa" "${haplotype1}" "genome1"
+else
+    validate_fasta_headers "haplo1/03_genome/${haplotype1}.fa" "" "genome1"
+fi
+
 #--- handling genome 2 -----
 if [[ -n "$genome2" ]] ; then
     
@@ -217,6 +361,8 @@ if [[ -n "$genome2" ]] ; then
         haplotype2="$(basename "${genome2%.fa**}")"
         mkdir -p haplo2/03_genome ; 
     fi
+
+    validate_simple_id "haplotype2" "${haplotype2}"
     
     #check genome compression:
     # ----- check compression of fasta  ------ ##
@@ -238,6 +384,8 @@ if [[ -n "$genome2" ]] ; then
         genome2=$genome2
         cd ../../
     fi
+
+    validate_fasta_headers "haplo2/03_genome/${haplotype2}.fa" "${haplotype2}" "genome2"
 fi
 
 #conda deactivate
@@ -2406,6 +2554,9 @@ if [ "$option" == 3 ] || [ "$option" == 4 ] || [ "$option" == 5 ]; then
             echo " "
         fi
 
+        validate_gtf_gene_ids "$gtf1" "$haplotype1" "gtf1"
+        validate_gtf_gene_ids "$gtf2" "$haplotype2" "gtf2"
+
         cp "$gtf1" haplo1/08_best_run/"${haplotype1}".final.gtf
         cp "$gtf2" haplo2/08_best_run/"${haplotype2}".final.gtf
         cp "$genome1" haplo1/03_genome/"${haplotype1}".fa
@@ -2460,6 +2611,8 @@ if [ "$option" == 3 ] || [ "$option" == 4 ] || [ "$option" == 5 ]; then
             echo " "
         fi
 
+        validate_gtf_gene_ids "$gtf1" "" "gtf1"
+
         cp "$gtf1" haplo1/08_best_run/"${haplotype1}".final.gtf
         cp "$genome1" haplo1/03_genome/"${haplotype1}".fa
 
@@ -2470,7 +2623,7 @@ if [ "$option" == 3 ] || [ "$option" == 4 ] || [ "$option" == 5 ]; then
             exit
         else
             gffread -g "$genome1" -y haplo1/08_best_run/"$haplotype1"_prot.final.clean.fa "$gtf1"
-            sed -i '/^>/!s/./*/g' haplo1/08_best_run/"$haplotype1"_prot.final.clean.fa 
+            sed -i '/^>/!s/\./*/g' haplo1/08_best_run/"$haplotype1"_prot.final.clean.fa 
             #transeq -sequence haplo1/08_best_run/"$haplotype1".spliced_cds.fa \
             #        -outseq haplo1/08_best_run/"$haplotype1"_prot.final.clean.fa
 


### PR DESCRIPTION
This PR includes a set of small fixes on installation, input checking, and workflow stability:

- Fixed a bug in `sed` that was replacing entire protein sequences instead of only `.` stop-codon characters.
- Normalized `.` to `*` in annotation-derived protein FASTA outputs so DIAMOND/OrthoFinder does not fail on invalid characters.
- Added stricter input validation in `master.sh` for FASTA headers, haplotype names, and GTF `gene_id` formats.
- Fixed a color-palette overflow issue in `plot_paml`.
- Activate the correct conda environment before downstream steps so tools like `bedtools`, `gffread`, and `transeq` are available when needed.
- Improved `INSTALL/dependencies.sh` by updating dependency setup, R/Bioconductor package installation, HTSlib/Augustus path handling, and allowing local installation instead of appending paths to `~/.bashrc`.

Please review these changes and merge whichever ones you find useful.